### PR TITLE
Fix deprecated usage of null instead of empty string and incorrect variable in thumbnail creation error 

### DIFF
--- a/library/plugins/userCookies.php
+++ b/library/plugins/userCookies.php
@@ -1,9 +1,9 @@
 <?php
 
 if ($logged) {
-    setcookie("blacklist", $user["blacklist"], time() + 606024 * 9999, "/");
-    setcookie("commentThreshold", $user["commentThreshold"], time() + 606024 * 9999, "/");
-    setcookie("postThreshold", $user["postThreshold"], time() + 606024 * 9999, "/");
-    setcookie("myTags", $user["myTags"], time() + 606024 * 9999, "/");
-    setcookie("safeOnly", $user["safeOnly"], time() + 606024 * 9999, "/");
+    setcookie("blacklist", $user["blacklist"] ?? "", time() + 606024 * 9999, "/");
+    setcookie("commentThreshold", $user["commentThreshold"] ?? "", time() + 606024 * 9999, "/");
+    setcookie("postThreshold", $user["postThreshold"] ?? "", time() + 606024 * 9999, "/");
+    setcookie("myTags", $user["myTags"] ?? "", time() + 606024 * 9999, "/");
+    setcookie("safeOnly", $user["safeOnly"] ?? "", time() + 606024 * 9999, "/");
 }

--- a/public/upload.php
+++ b/public/upload.php
@@ -81,7 +81,7 @@ if (isset($_POST["upload"])) {
                                             ->toFile(platformSlashes($config["db"]["thumbs"][1] . "/" . $newFilename . $fileTypeWithDot), 'image/png');
                                     } catch (Exception $err) {
                                         // Handle errors
-                                        doLog("upload", false, "error at thumbnail creation: " . $erro->getMessage(), $user["_id"]);
+                                        doLog("upload", false, "error at thumbnail creation: " . $err->getMessage(), $user["_id"]);
                                         $smarty->assign("error", "Thumbnail creation: " . $err->getMessage());
                                         $error = true;
                                     }

--- a/session.php
+++ b/session.php
@@ -2,11 +2,11 @@
 
 $logged = false;
 $user = array(
-    "blacklist" => clean($_COOKIE["blacklist"] ?? null),
-    "commentThreshold" => clean($_COOKIE["commentThreshold"] ?? null),
-    "postThreshold" => clean($_COOKIE["postThreshold"] ?? null),
-    "myTags" => clean($_COOKIE["myTags"] ?? null),
-    "safeOnly" => clean($_COOKIE["safeOnly"] ?? null)
+    "blacklist" => clean($_COOKIE["blacklist"] ?? ""),
+    "commentThreshold" => clean($_COOKIE["commentThreshold"] ?? ""),
+    "postThreshold" => clean($_COOKIE["postThreshold"] ?? ""),
+    "myTags" => clean($_COOKIE["myTags"] ?? ""),
+    "safeOnly" => clean($_COOKIE["safeOnly"] ?? "")
 );
 if (isset($_COOKIE["session"]) && !empty($_COOKIE["session"])) {
     $token = clean($_COOKIE["session"]);


### PR DESCRIPTION
If null is passed into these functions it spits out  deprecation warnings into the page, replacing with empty strings fixes it